### PR TITLE
#76 MI 6 can't find x.png

### DIFF
--- a/src/com/skyline/wxjumphack/Hack.java
+++ b/src/com/skyline/wxjumphack/Hack.java
@@ -43,6 +43,9 @@ public class Hack {
                 process = Runtime.getRuntime().exec(ADB_PATH + " pull /sdcard/screenshot.png " + file.getAbsolutePath());
                 process.waitFor();
 
+                if (!file.exists()){
+                    continue;
+                }
                 System.out.println("screenshot, file: " + file.getAbsolutePath());
                 BufferedImage image = ImgLoader.load(file.getAbsolutePath());
                 if (jumpRatio == 0) {


### PR DESCRIPTION
continue when screenshot file is not exists(Sometimes screenshot file copied to PC unsuccessfully)